### PR TITLE
upgrade aws provider version to ~>6.0

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -1,6 +1,7 @@
 resource "aws_backup_plan" "environment" {
-  name  = "${var.tag_environment}-backup-plan"
-  count = var.backup.enabled ? 1 : 0
+  region = var.region
+  name   = "${var.tag_environment}-backup-plan"
+  count  = var.backup.enabled ? 1 : 0
 
   rule {
     rule_name         = "${var.backup.retention}-day-retention"
@@ -18,14 +19,16 @@ resource "aws_backup_plan" "environment" {
 }
 
 resource "aws_backup_vault" "environment" {
-  count = var.backup.enabled ? 1 : 0
-  name  = "${var.tag_environment}-backup-vault"
+  region = var.region
+  count  = var.backup.enabled ? 1 : 0
+  name   = "${var.tag_environment}-backup-vault"
   tags = {
     Environment = var.tag_environment
   }
 }
 
 resource "aws_backup_selection" "environment" {
+  region       = var.region
   count        = var.backup.enabled ? 1 : 0
   iam_role_arn = aws_iam_role.backup[0].arn
   name         = "${var.tag_environment}-servers"

--- a/instances_on_demand.tf
+++ b/instances_on_demand.tf
@@ -28,6 +28,7 @@ module "on_demand_requests" {
 }
 
 resource "aws_eip" "on_demand_requests" {
+  region   = var.region
   for_each = { for name, instance in var.on_demand_requests : name => coalesce(instance.hostname, "${name}-${var.tag_environment}.${var.route53_zone_name}") if instance.subnet_type == "public" }
 
   tags = {
@@ -38,6 +39,7 @@ resource "aws_eip" "on_demand_requests" {
 }
 
 resource "aws_eip_association" "on_demand_requests" {
+  region   = var.region
   for_each = { for name, instance in var.on_demand_requests : name => module.on_demand_requests[name] if instance.subnet_type == "public" }
 
   instance_id   = each.value.instance_id

--- a/instances_on_demand.tf
+++ b/instances_on_demand.tf
@@ -1,6 +1,7 @@
 module "on_demand_requests" {
   source  = "frgrisk/ec2-instance/aws"
-  version = "~>0.4.0"
+  version = "~>0.5.0"
+  region  = var.region
 
   for_each = var.on_demand_requests
 
@@ -11,7 +12,7 @@ module "on_demand_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.security_group_id],
+    [module.intra_environment_traffic.id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/instances_spot.tf
+++ b/instances_spot.tf
@@ -4,7 +4,8 @@ locals {
 
 module "spot_requests" {
   source  = "frgrisk/ec2-spot/aws"
-  version = "~>0.6.0"
+  version = "~>0.7.0"
+  region  = var.region
 
   for_each = var.spot_requests
 
@@ -15,7 +16,7 @@ module "spot_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.security_group_id],
+    [module.intra_environment_traffic.id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/instances_spot.tf
+++ b/instances_spot.tf
@@ -32,6 +32,7 @@ module "spot_requests" {
 }
 
 resource "aws_eip" "spot_requests" {
+  region   = var.region
   for_each = { for name, instance in var.spot_requests : name => coalesce(instance.hostname, "${name}-${var.tag_environment}.${var.route53_zone_name}") if instance.subnet_type == "public" }
 
   tags = {
@@ -42,6 +43,7 @@ resource "aws_eip" "spot_requests" {
 }
 
 resource "aws_eip_association" "spot_requests" {
+  region   = var.region
   for_each = { for name, instance in var.spot_requests : name => module.spot_requests[name] if instance.subnet_type == "public" }
 
   instance_id   = each.value.instance_id

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.5.7"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~>6.0"
     }
   }
 }

--- a/networking.tf
+++ b/networking.tf
@@ -68,6 +68,10 @@ module "intra_environment_traffic" {
   description = "${var.tag_environment} inter-subnet traffic"
   vpc_id      = var.vpc_id
 
+  tags = {
+    Name = "${var.tag_environment} inter-subnet traffic"
+  }
+
   ingress_rules = {
     all = {
       ip_protocol = "-1"

--- a/networking.tf
+++ b/networking.tf
@@ -62,16 +62,28 @@ resource "aws_route_table_association" "public" {
 
 module "intra_environment_traffic" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~>5.0"
+  version = "~>6.0"
+  region  = var.region
 
   name        = "${var.tag_environment} inter-subnet traffic"
   description = "${var.tag_environment} inter-subnet traffic"
   vpc_id      = var.vpc_id
 
-  ingress_cidr_blocks = [var.environment_cidr]
+  ingress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = var.environment_cidr
+      description = "Allow all traffic between subnets in the environment"
+    }
+  }
 
-  ingress_rules = ["all-all"]
-  egress_rules  = ["all-all"]
+  egress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "Allow all traffic to exit the environment"
+    }
+  }
 }
 
 moved {

--- a/networking.tf
+++ b/networking.tf
@@ -84,7 +84,7 @@ module "intra_environment_traffic" {
     all = {
       ip_protocol = "-1"
       cidr_ipv4   = "0.0.0.0/0"
-      description = "Allow all traffic to exit the environment"
+      description = "Allow all outbound traffic"
     }
   }
 }

--- a/networking.tf
+++ b/networking.tf
@@ -10,21 +10,17 @@ locals {
   public_subnet_cidrs  = slice(local.all_subnets, local.number_of_subnets / 2, local.number_of_subnets)
 }
 
-data "aws_region" "current" {}
-
 data "aws_availability_zones" "region" {
+  region = var.region
+
   filter {
     name   = "opt-in-status"
     values = ["opt-in-not-required"]
   }
-
-  filter {
-    name   = "region-name"
-    values = [data.aws_region.current.name]
-  }
 }
 
 resource "aws_subnet" "private" {
+  region   = var.region
   for_each = toset(data.aws_availability_zones.region.names)
   tags = {
     Name        = "${var.tag_environment}-private-${each.key}"
@@ -36,6 +32,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_subnet" "public" {
+  region   = var.region
   for_each = toset(data.aws_availability_zones.region.names)
   tags = {
     Name        = "${var.tag_environment}-public-${each.key}"
@@ -47,6 +44,7 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_route_table_association" "private" {
+  region   = var.region
   for_each = aws_subnet.private
 
   route_table_id = var.private_route_table_id
@@ -54,6 +52,7 @@ resource "aws_route_table_association" "private" {
 }
 
 resource "aws_route_table_association" "public" {
+  region   = var.region
   for_each = aws_subnet.public
 
   route_table_id = var.public_route_table_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,12 +30,12 @@ output "public_subnets_by_az" {
 
 output "intra_environment_security_group_id" {
   description = "ID of the intra-environment security group"
-  value       = module.intra_environment_traffic.security_group_id
+  value       = module.intra_environment_traffic.id
 }
 
 output "inter_environment_security_group_id" {
   description = "DEPRECATED: ID of the intra-environment security group (use intra_environment_security_group_id instead)"
-  value       = module.intra_environment_traffic.security_group_id
+  value       = module.intra_environment_traffic.id
 }
 
 output "private_ip_addresses_on_demand" {

--- a/route53.tf
+++ b/route53.tf
@@ -34,7 +34,8 @@ resource "aws_route53_zone" "reverse" {
   name = local.reverse_dns_zone
 
   vpc {
-    vpc_id = var.vpc_id
+    vpc_id     = var.vpc_id
+    vpc_region = var.region
   }
 
   tags = merge(var.default_tags, { Environment = var.tag_environment })

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "allow_intra_environment_traffic" {
   type        = bool
   default     = true
 }
+
+variable "region" {
+  description = "The AWS region to deploy into"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
With the latest AWS Provider release for Terraform, a new feature called Enhanced Region Support is now available. This allows users to deploy resources across multiple regions by specifying the region argument directly within resource and data blocks, rather than maintaining separate provider configurations for each region.

This allows our configuration to be made simpler as we can rely on a single provider setup instead of having to configure multiple providers with one in each region as we have done previously.

The goal of this PR is to upgrade the Terraform version used in this module and enable users to pass a region argument, which will automatically cascade through the module’s resources.

A lot has changed for this module between v5 and v6, the full details can be read [here](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/master/docs/UPGRADE-6.0.md) but the main changes for us is that:

- Bumped the aws provider version requirement to v6.
-  A minimum terraform version requirement is added.
- region variables are added to where it's relevant.
- terraform-aws-modules/security-group/aws module no longer supports using predefined rules, rules have to be manually added one by one instead.