### PR TITLE
downgrade security group module version to ~>5.0

### DIFF
--- a/instances_on_demand.tf
+++ b/instances_on_demand.tf
@@ -12,7 +12,7 @@ module "on_demand_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.id],
+    [module.intra_environment_traffic.security_group_id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/instances_spot.tf
+++ b/instances_spot.tf
@@ -16,7 +16,7 @@ module "spot_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.id],
+    [module.intra_environment_traffic.security_group_id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/networking.tf
+++ b/networking.tf
@@ -61,32 +61,16 @@ resource "aws_route_table_association" "public" {
 
 module "intra_environment_traffic" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~>6.0"
-  region  = var.region
+  version = "~>5.0"
 
   name        = "${var.tag_environment} inter-subnet traffic"
   description = "${var.tag_environment} inter-subnet traffic"
   vpc_id      = var.vpc_id
 
-  tags = {
-    Name = "${var.tag_environment} inter-subnet traffic"
-  }
+  ingress_cidr_blocks = [var.environment_cidr]
 
-  ingress_rules = {
-    all = {
-      ip_protocol = "-1"
-      cidr_ipv4   = var.environment_cidr
-      description = "Allow all traffic between subnets in the environment"
-    }
-  }
-
-  egress_rules = {
-    all = {
-      ip_protocol = "-1"
-      cidr_ipv4   = "0.0.0.0/0"
-      description = "Allow all outbound traffic"
-    }
-  }
+  ingress_rules = ["all-all"]
+  egress_rules  = ["all-all"]
 }
 
 moved {

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,12 +30,12 @@ output "public_subnets_by_az" {
 
 output "intra_environment_security_group_id" {
   description = "ID of the intra-environment security group"
-  value       = module.intra_environment_traffic.id
+  value       = module.intra_environment_traffic.security_group_id
 }
 
 output "inter_environment_security_group_id" {
   description = "DEPRECATED: ID of the intra-environment security group (use intra_environment_security_group_id instead)"
-  value       = module.intra_environment_traffic.id
+  value       = module.intra_environment_traffic.security_group_id
 }
 
 output "private_ip_addresses_on_demand" {


### PR DESCRIPTION
Due to a change with the way that the security groups are managed in v6, it will cause the the security groups to be destroyed and recreated.

The issue with this is that when the security groups are recreated, so too will our spot instances that reference the security group. Because of such, the plan is to downgrade the security groups module and slowly migrate over our environments to use v6.