### PR TITLE
upgrade security group module to ~>6.0

### DIFF
--- a/instances_on_demand.tf
+++ b/instances_on_demand.tf
@@ -12,7 +12,7 @@ module "on_demand_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.security_group_id],
+    [module.intra_environment_traffic.id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/instances_spot.tf
+++ b/instances_spot.tf
@@ -16,7 +16,7 @@ module "spot_requests" {
   placement_group      = each.value.placement_group
   security_group_ids = var.allow_intra_environment_traffic ? concat(
     each.value.security_group_ids,
-    [module.intra_environment_traffic.security_group_id],
+    [module.intra_environment_traffic.id],
   ) : each.value.security_group_ids
   subnet_id          = each.value.subnet_type == "public" ? aws_subnet.public[coalesce(each.value.availability_zone, local.default_az)].id : aws_subnet.private[coalesce(each.value.availability_zone, local.default_az)].id
   tag_environment    = var.tag_environment

--- a/networking.tf
+++ b/networking.tf
@@ -61,16 +61,32 @@ resource "aws_route_table_association" "public" {
 
 module "intra_environment_traffic" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "~>5.0"
+  version = "~>6.0"
+  region  = var.region
 
   name        = "${var.tag_environment} inter-subnet traffic"
   description = "${var.tag_environment} inter-subnet traffic"
   vpc_id      = var.vpc_id
 
-  ingress_cidr_blocks = [var.environment_cidr]
+  tags = {
+    Name = "${var.tag_environment} inter-subnet traffic"
+  }
 
-  ingress_rules = ["all-all"]
-  egress_rules  = ["all-all"]
+  ingress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = var.environment_cidr
+      description = "Allow all traffic between subnets in the environment"
+    }
+  }
+
+  egress_rules = {
+    all = {
+      ip_protocol = "-1"
+      cidr_ipv4   = "0.0.0.0/0"
+      description = "Allow all outbound traffic"
+    }
+  }
 }
 
 moved {

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,12 +30,12 @@ output "public_subnets_by_az" {
 
 output "intra_environment_security_group_id" {
   description = "ID of the intra-environment security group"
-  value       = module.intra_environment_traffic.security_group_id
+  value       = module.intra_environment_traffic.id
 }
 
 output "inter_environment_security_group_id" {
   description = "DEPRECATED: ID of the intra-environment security group (use intra_environment_security_group_id instead)"
-  value       = module.intra_environment_traffic.security_group_id
+  value       = module.intra_environment_traffic.id
 }
 
 output "private_ip_addresses_on_demand" {


### PR DESCRIPTION
This PR reverts the changes made in #26 for environments that are ready to be migrated to the new version of the security group module.