### PR TITLE
Extend backup capabilities to allow multiple rules per plan

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -2,13 +2,16 @@ resource "aws_backup_plan" "environment" {
   name  = "${var.tag_environment}-backup-plan"
   count = var.backup.enabled ? 1 : 0
 
-  rule {
-    rule_name         = "${var.backup.retention}-day-retention"
-    target_vault_name = aws_backup_vault.environment[0].name
-    schedule          = var.backup.schedule
+  dynamic "rule" {
+    for_each = var.backup.rules
+    content {
+      rule_name         = rule.key
+      target_vault_name = aws_backup_vault.environment[0].name
+      schedule          = rule.value.schedule
 
-    lifecycle {
-      delete_after = var.backup.retention
+      lifecycle {
+        delete_after = rule.value.retention
+      }
     }
   }
 

--- a/backup.tf
+++ b/backup.tf
@@ -8,6 +8,7 @@ resource "aws_backup_plan" "environment" {
       rule_name         = rule.key
       target_vault_name = aws_backup_vault.environment[0].name
       schedule          = rule.value.schedule
+      completion_window = rule.value.completion_window
 
       lifecycle {
         delete_after = rule.value.retention

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,3 +67,33 @@ output "reverse_dns_zone_id" {
   description = "Reverse DNS zone ID"
   value       = aws_route53_zone.reverse.zone_id
 }
+
+output "backup_vault_name" {
+  description = "Name of the backup vault"
+  value       = one(aws_backup_vault.environment[*].name)
+}
+
+output "backup_vault_arn" {
+  description = "ARN of the backup vault"
+  value       = one(aws_backup_vault.environment[*].arn)
+}
+
+output "backup_plan_id" {
+  description = "ID of the backup plan"
+  value       = one(aws_backup_plan.environment[*].id)
+}
+
+output "backup_plan_arn" {
+  description = "ARN of the backup plan"
+  value       = one(aws_backup_plan.environment[*].arn)
+}
+
+output "backup_role_name" {
+  description = "Name of the IAM role used by AWS Backup"
+  value       = one(aws_iam_role.backup[*].name)
+}
+
+output "backup_role_arn" {
+  description = "ARN of the IAM role used by AWS Backup"
+  value       = one(aws_iam_role.backup[*].arn)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,22 +41,24 @@ variable "on_demand_requests" {
 variable "backup" {
   description = "Map of backup variables"
   type = object({
-    enabled   = bool
-    schedule  = optional(string)
-    retention = optional(number)
+    enabled = bool
+    rules = optional(map(object({
+      schedule  = string
+      retention = number
+    })), {})
   })
   default = {
     enabled = false
   }
 
   validation {
-    condition     = var.backup.enabled == true ? var.backup.schedule != null && var.backup.retention != null : true
-    error_message = "If backup is enabled, schedule and retention must be set"
+    condition     = var.backup.enabled == true ? length(var.backup.rules) > 0 : true
+    error_message = "If backup is enabled, at least one rule must be defined in rules"
   }
 
   validation {
-    condition     = var.backup.enabled == false ? var.backup.schedule == null && var.backup.retention == null : true
-    error_message = "If backup is disabled, schedule and retention must be null"
+    condition     = var.backup.enabled == false ? length(var.backup.rules) == 0 : true
+    error_message = "If backup is disabled, rules must be empty"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -43,8 +43,9 @@ variable "backup" {
   type = object({
     enabled = bool
     rules = optional(map(object({
-      schedule  = string
-      retention = number
+      schedule          = string
+      retention         = number
+      completion_window = optional(number)
     })), {})
   })
   default = {


### PR DESCRIPTION
## Summary
Currently with the way that the environment modules is set up, the backup created for the environment can only be configured to one rule. The purpose of this PR is to extend that and allow multiple rules to be configured per plan.

Besides that, some other smaller changes are also made in this PR.

## Changes
- Multiple rules can be defined in a single plan.
- Backup rules are no longer named based on the retention days but instead it is based on the key of the rule configured in terraform.
- The completion window for backups can now be adjusted.
- Output information regarding the backup resources are now exported for reference by other terraform resources.

## Breaking Change
To allow specifying multiple rules per plan, the structure of the backup variable now has to be updated to accommodate this. This means that for users of the version (~>0.9.0) of this module their old backup configuration has to be updated to match the new one.

An example of updating the structure is as such:
**old configuration**
```
backup = {
    enabled   = true
    schedule  = "cron(0 19 ? * MON,WED,FRI *)"
    retention = 10
}
```

**new configuration**
```
backup = {
    enabled   = true
    rules = {
        weekday = {
            schedule  = "cron(0 19 ? * MON,WED,FRI *)"
            retention = 10
        }
    } 
}
```